### PR TITLE
Check MFA only for users with console access

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -18,8 +18,11 @@ func main() {
 		Use:   "plio",
 		Short: "plio checks if your infra is SOC2 compliant",
 		Run: func(cmd *cobra.Command, _ []string) {
-			aws := integration.NewAWS()
-			_, err := aws.Check()
+			aws, err := integration.NewAWS()
+			if err != nil {
+				klog.Exitf("Failed to create AWS integration: %v", err)
+			}
+			_, err = aws.Check()
 			if err != nil {
 				klog.Exitf("AWS check failed: %v", err)
 			}


### PR DESCRIPTION
Following the specification of
https://docs.aws.amazon.com/config/latest/developerguide/mfa-enabled-for-iam-console-access.html, only users with console passwords need MFA.