### PR TITLE
server: build static binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ cli: install_deps
 	go build -o out/plio -v ./cmd
 
 server: install_deps
-	go build -o out/server -v ./server
+	CGO_ENABLED=0 go build -ldflags '-extldflags "-static"' -o out/server -v ./server
 
 install_deps:
 	go get -v ./...

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,9 +1,8 @@
 FROM golang:1.21 AS build
 WORKDIR /go/src
 COPY . .
-
 RUN make server
 
 FROM scratch AS runtime
-COPY --from=build /go/src/server ./
-ENTRYPOINT ["./server"]
+COPY --from=build /go/src/out/server /server
+ENTRYPOINT ["/server"]


### PR DESCRIPTION
This was preventing the server from running in a scratch base image.