### PR TITLE
server: move certificate namespace to istio-system

### DIFF
--- a/server/infra/base/certificate.yaml
+++ b/server/infra/base/certificate.yaml
@@ -2,7 +2,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: plio
-  namespace: plio
+  namespace: istio-system
 spec:
   secretName: plio
   duration: 2160h # 90d

--- a/server/infra/base/deployment.yaml
+++ b/server/infra/base/deployment.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: plio
-  namespace: plio
 spec:
   replicas: 2
   strategy:

--- a/server/infra/base/gateway.yaml
+++ b/server/infra/base/gateway.yaml
@@ -2,7 +2,6 @@ apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
   name: plio
-  namespace: plio
 spec:
   selector:
     istio: ingressgateway

--- a/server/infra/base/service.yaml
+++ b/server/infra/base/service.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: plio
-  namespace: plio
 spec:
   ports:
     - port: 8000

--- a/server/infra/base/serviceaccount.yaml
+++ b/server/infra/base/serviceaccount.yaml
@@ -1,5 +1,4 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  namespace: plio
   name: plio

--- a/server/infra/base/virtual-service.yaml
+++ b/server/infra/base/virtual-service.yaml
@@ -2,7 +2,6 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: plio
-  namespace: plio
 spec:
   hosts:
   - "api.runplio.com"

--- a/server/infra/demo/kustomization.yaml
+++ b/server/infra/demo/kustomization.yaml
@@ -1,7 +1,14 @@
 resources:
 - ./../base
 nameSuffix: -demo
-namespace: plio-demo
+transformers:
+  - |-
+    apiVersion: builtin
+    kind: NamespaceTransformer
+    metadata:
+      name: unused
+      namespace: plio-demo
+    unsetOnly: true
 patches:
 - patch: |-
     - op: replace


### PR DESCRIPTION
The Istio Gateway CRD doesn't read cross-namespace secrets - see https://github.com/istio/istio/issues/14598. In the future, we could move this back to a plio namespace by adopting the k8s native Gateway APIs.