### PR TITLE
server: configure kubeconfig during deploy workflow

### DIFF
--- a/.github/workflows/deploy-server.yml
+++ b/.github/workflows/deploy-server.yml
@@ -35,6 +35,7 @@ jobs:
         role-to-assume: arn:aws:iam::666190772232:role/PlioGithubActions
         role-session-name: plio-deploy
         aws-region: us-east-1
+    - run: aws eks update-kubeconfig --name app-server --region us-east-1
     - run: |
         curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
         curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh"  | bash


### PR DESCRIPTION
Without this, Github doesn't know where to deploy to.