### PR TITLE
server: provide more detailed messages from integrations

### DIFF
--- a/integration/aws.go
+++ b/integration/aws.go
@@ -71,7 +71,7 @@ func (i *IAM) checkConsoleMFA() error {
 	}
 
 	if len(nonMFAUsers) > 0 {
-		return fmt.Errorf("MFA not enabled for users %v", nonMFAUsers)
+		return fmt.Errorf("MFA not enabled for users %v with console access", nonMFAUsers)
 	}
 
 	return nil

--- a/server/main.go
+++ b/server/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	klog "k8s.io/klog/v2"
@@ -50,7 +51,7 @@ func runAWSIntegration(w http.ResponseWriter, _ *http.Request) {
 
 	if err = aws.Check(); err != nil {
 		klog.ErrorS(err, "AWS check failed")
-		awsResp("AWS check failed", "failed")
+		awsResp(fmt.Sprintf("%v", err), "noncompliant")
 		return
 	}
 


### PR DESCRIPTION
The old output could be misinterpreted as saying that the integration itself failed to complete, rather than finding noncompliant configuration.