### PR TITLE
server: skip copy from scratch build stage

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -2,7 +2,4 @@ FROM golang:1.21 AS build
 WORKDIR /go/src
 COPY . .
 RUN make server
-
-FROM scratch AS runtime
-COPY --from=build /go/src/out/server /server
-ENTRYPOINT ["/server"]
+ENTRYPOINT ["/go/src/out/server"]


### PR DESCRIPTION
The scratch image is missing trust roots for AWS endpoints.