### PR TITLE
integration/aws: add stale IAM access key check

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
 
 	"github.com/spf13/cobra"
@@ -17,14 +18,21 @@ func main() {
 	rootCmd := &cobra.Command{
 		Use:   "plio",
 		Short: "plio checks if your infra is SOC2 compliant",
-		Run: func(_ *cobra.Command, _ []string) {
+		Run: func(cmd *cobra.Command, _ []string) {
 			aws, err := integration.NewAWS()
 			if err != nil {
-				klog.Exitf("Failed to create AWS integration: %v", err)
+				klog.Exitf("AWS integration creation failed: %v", err)
 			}
-			if err = aws.Check(); err != nil {
+			res, err := aws.Check()
+			if err != nil {
 				klog.Exitf("AWS check failed: %v", err)
 			}
+			// convert res to json and print out using command
+			jsonRes, err := json.Marshal(res)
+			if err != nil {
+				klog.Exitf("result serialization failed: %v", err)
+			}
+			cmd.Println(string(jsonRes))
 		},
 	}
 

--- a/integration/aws.go
+++ b/integration/aws.go
@@ -1,12 +1,11 @@
 package integration
 
 import (
-	"fmt"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/iam"
-	klog "k8s.io/klog/v2"
 )
 
 // AWS checks that the user's AWS infra is SOC2 compliant
@@ -25,7 +24,7 @@ func NewAWS() (*AWS, error) {
 }
 
 // Check checks that the user's AWS infra is SOC2 compliant
-func (a *AWS) Check() error {
+func (a *AWS) Check() ([]Result, error) {
 	return a.IAM.Check()
 }
 
@@ -40,39 +39,106 @@ func NewIAM(s *session.Session) *IAM {
 }
 
 // Check checks that the user's IAM infra is SOC2 compliant
-func (i *IAM) Check() error {
-	return i.checkConsoleMFA()
+func (i *IAM) Check() ([]Result, error) {
+	mfaRes, err := i.checkConsoleMFA()
+	if err != nil {
+		return nil, err
+	}
+
+	staleCredsRes, err := i.checkIAMUsersUnusedCreds()
+	if err != nil {
+		return nil, err
+	}
+
+	return append(mfaRes, staleCredsRes...), nil
 }
 
 // checkConsoleMFA checks that IAM users with console access have MFA enabled
-func (i *IAM) checkConsoleMFA() error {
-	nonMFAUsers := []string{}
+func (i *IAM) checkConsoleMFA() ([]Result, error) {
+	var mfaRes []Result
+	rule := "IAM users with console access must have MFA enabled"
 
 	users, err := i.iamAPI.ListUsers(&iam.ListUsersInput{})
 	if err != nil {
-		return err
+		return nil, err
 	}
+
 	for _, user := range users.Users {
 		mfa, err := i.iamAPI.ListMFADevices(&iam.ListMFADevicesInput{UserName: user.UserName})
 		if err != nil {
-			return err
+			return nil, err
 		}
+
 		_, err = i.iamAPI.GetLoginProfile(&iam.GetLoginProfileInput{UserName: user.UserName})
 		if err != nil {
-			klog.V(4).InfoS("User does not have console access; skipping MFA check", "user", aws.StringValue(user.UserName))
+			mfaRes = append(
+				mfaRes,
+				i.userResult(user, rule, true, "User does not have console access"),
+			)
 			continue
 		}
 
 		if mfa.MFADevices == nil {
-			nonMFAUsers = append(nonMFAUsers, aws.StringValue(user.UserName))
+			mfaRes = append(
+				mfaRes,
+				i.userResult(user, rule, false, "User does not have MFA enabled"),
+			)
 		} else {
-			klog.V(4).InfoS("MFA enabled", "user", aws.StringValue(user.UserName))
+			mfaRes = append(mfaRes, i.userResult(user, rule, true, ""))
 		}
 	}
 
-	if len(nonMFAUsers) > 0 {
-		return fmt.Errorf("MFA not enabled for users %v with console access", nonMFAUsers)
+	return mfaRes, nil
+}
+
+// checkIAMUsersUnusedCreds checks that IAM users have no unused credentials
+func (i *IAM) checkIAMUsersUnusedCreds() ([]Result, error) {
+	var staleCredsRes []Result
+	rule := "IAM users must not have credentials unused in the last 90 days"
+
+	users, err := i.iamAPI.ListUsers(&iam.ListUsersInput{})
+	if err != nil {
+		return nil, err
+	}
+	for _, user := range users.Users {
+		accessKeys, err := i.iamAPI.ListAccessKeys(
+			&iam.ListAccessKeysInput{UserName: user.UserName})
+		if err != nil {
+			return nil, err
+		}
+
+		for _, accessKey := range accessKeys.AccessKeyMetadata {
+			if aws.StringValue(accessKey.Status) != "Active" {
+				continue
+			}
+
+			out, err := i.iamAPI.GetAccessKeyLastUsed(
+				&iam.GetAccessKeyLastUsedInput{AccessKeyId: accessKey.AccessKeyId})
+			if err != nil {
+				return nil, err
+			}
+			if out.AccessKeyLastUsed.LastUsedDate != nil && out.AccessKeyLastUsed.LastUsedDate.AddDate(0, 0, 90).Before(time.Now()) {
+				staleCredsRes = append(
+					staleCredsRes,
+					i.userResult(user, rule, false, "User has credentials unused for more than 90 days"),
+				)
+			} else {
+				staleCredsRes = append(staleCredsRes, i.userResult(user, rule, true, ""))
+			}
+		}
 	}
 
-	return nil
+	return staleCredsRes, nil
+}
+
+func (i *IAM) userResult(user *iam.User, rule string, compliant bool, reason string) Result {
+	return Result{
+		Resource: Resource{
+			Type: "aws/iam-user",
+			Name: aws.StringValue(user.Arn),
+		},
+		Rule:      rule,
+		Compliant: compliant,
+		Reason:    reason,
+	}
 }

--- a/integration/resource.go
+++ b/integration/resource.go
@@ -1,0 +1,13 @@
+package integration
+
+type Result struct {
+	Resource  Resource `json:"resource"`
+	Rule      string   `json:"rule"`
+	Compliant bool     `json:"compliant"`
+	Reason    string   `json:"reason"`
+}
+
+type Resource struct {
+	Type string `json:"type"`
+	Name string `json:"name"`
+}


### PR DESCRIPTION
CC6.1 - The entity implements logical access security software, infrastructure, and architectures over protected information assets to protect them from security events to meet the entity's objectives.